### PR TITLE
Fix VALIDATE_AUTH_TOKENS

### DIFF
--- a/config.php
+++ b/config.php
@@ -149,7 +149,7 @@ return [
         | admin interface.
         |
         */
-        'validate_auth_tokens' => env('VALIDATE_AUTH_TOKENS'),
+        'validate_auth_tokens' => env('VALIDATE_AUTH_TOKENS', false),
 
         /*
         |--------------------------------------------------------------------------


### PR DESCRIPTION
Give it default of "false" will safe you from startup issues if you forget to pass the variable.